### PR TITLE
Bug fix for modifying overlays during build.

### DIFF
--- a/lib/src/layout_overlays.dart
+++ b/lib/src/layout_overlays.dart
@@ -95,20 +95,20 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
     super.initState();
 
     if (widget.showOverlay) {
-      showOverlay();
+      WidgetsBinding.instance.addPostFrameCallback((_) => showOverlay());
     }
   }
 
   @override
   void didUpdateWidget(OverlayBuilder oldWidget) {
     super.didUpdateWidget(oldWidget);
-    syncWidgetAndOverlay();
+    WidgetsBinding.instance.addPostFrameCallback((_) => syncWidgetAndOverlay());
   }
 
   @override
   void reassemble() {
     super.reassemble();
-    syncWidgetAndOverlay();
+    WidgetsBinding.instance.addPostFrameCallback((_) => syncWidgetAndOverlay());
   }
 
   @override


### PR DESCRIPTION
@matthew-carroll I know you've been in contact with @ScottS2017 about an issue he's been having.

I've had time to look into the issue. Seem's as though because `AnchoredOverlay` wraps an `OverlayBuilder` with a `LayoutBuilder` the overlay is now considered to be laid-out during build.

Like my `after_layout` package the change here simply posts the update to the end of the current frame so we have laid out the screen and build has finished.